### PR TITLE
 v0.0.5 (Arlington)

### DIFF
--- a/dev/DebuggerKit/NeKernelContract.h
+++ b/dev/DebuggerKit/NeKernelContract.h
@@ -17,12 +17,13 @@ namespace DebuggerKit::NeKernel {
 class NeKernelContract;
 
 namespace Detail {
-  inline constexpr auto kDebugCmdLen  = 256U;
-  inline constexpr auto kDebugPort    = 51820;
-  inline constexpr auto kDebugMagic   = "VMK1.0.0;";
-  inline constexpr auto kDebugVersion = 0x0100;
-  typedef char          dk_debug_cmd_type[kDebugCmdLen];
-  typedef int64_t       dk_socket_type;
+  inline constexpr auto     kDebugCmdLen  = 256U;
+  inline constexpr auto     kDebugPort    = 51820;
+  inline constexpr auto     kDebugMagic   = "VMK1.0.0;";
+  inline constexpr uint16_t kDebugVersion = 0x0100;
+  inline constexpr auto     kDebugDelim   = ';';
+  inline constexpr auto     kDebugEnd     = '\r';
+  typedef int64_t           dk_socket_type;
 }  // namespace Detail
 
 class NeKernelContract DK_DEBUGGER_CONTRACT {
@@ -42,9 +43,8 @@ class NeKernelContract DK_DEBUGGER_CONTRACT {
   bool Detach() noexcept override;
 
  private:
-  dk_debug_cmd_type m_buffer;
-  std::string       m_kernel_path{};
-  dk_socket_type    m_socket{0};
+  CompilerKit::STLString m_kernel_path{};
+  Detail::dk_socket_type m_socket{0};
 };
 }  // namespace DebuggerKit::NeKernel
 

--- a/dev/DebuggerKit/Platform.h
+++ b/dev/DebuggerKit/Platform.h
@@ -2,16 +2,15 @@
   DebuggerKit
   (C) 2025 Amlal El Mahrouss
   File: NeKernelContract.cc
-  Purpose: NeKernel Debugger
+  Purpose: NeKernel Debugger Platform include.
 */
 
 #pragma once
 
-#ifdef DEBUGGERKIT_POSIX
+/// @author Amlal El Mahrouss
+
+#include <arpa/inet.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
-#else
-#error !!! DebuggerKit needs a networking backend !!!
-#endif

--- a/dev/DebuggerKit/dk-nekernel.json
+++ b/dev/DebuggerKit/dk-nekernel.json
@@ -1,5 +1,5 @@
 {
-  "compiler_path": "g++",
+  "compiler_path": "clang++",
   "compiler_std": "c++20",
   "headers_path": [
     "../DebuggerKit",
@@ -10,7 +10,7 @@
   "compiler_flags": ["-fPIC", "-shared"],
   "cpp_macros": [
     "__NECTI__=202505",
-    "CK_USE_STRUCTS=1",
+    "DK_USE_STRUCTS=1",
     "DK_NEKERNEL_DEBUGGER",
     "kDistReleaseBranch=$(git rev-parse --abbrev-ref HEAD)-$(uuidgen)"
   ]

--- a/dev/DebuggerKit/src/NeKernelContract.cc
+++ b/dev/DebuggerKit/src/NeKernelContract.cc
@@ -16,6 +16,7 @@
 #include <ThirdParty/Dialogs.h>
 
 using namespace DebuggerKit::NeKernel;
+using namespace DebuggerKit::NeKernel::Detail;
 
 NeKernelContract::NeKernelContract() = default;
 
@@ -24,23 +25,67 @@ NeKernelContract::~NeKernelContract() = default;
 BOOL NeKernelContract::Attach(CompilerKit::STLString path, CompilerKit::STLString argv,
                               ProcessID& pid) noexcept {
   if (path.empty() || argv.empty()) return NO;
-  return NO;
+
+  m_socket = ::socket(AF_INET, SOCK_STREAM, 0);
+
+  if (m_socket == -1) return NO;
+
+  struct sockaddr_in server_addr;
+
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port   = htons(kDebugPort);
+
+  if (::inet_pton(AF_INET, argv.c_str(), &server_addr.sin_addr) <= 0) return NO;
+
+  auto ret = (::connect(m_socket, (struct sockaddr*) &server_addr, sizeof(server_addr)) == -1);
+
+  if (ret) return NO;
+
+  CompilerKit::STLString pkt = Detail::kDebugMagic;
+  pkt += ";\r";
+
+  ret = ::send(m_socket, pkt.data(), pkt.size(), 0) > 0;
+  return ret;
 }
 
 BOOL NeKernelContract::BreakAt(CompilerKit::STLString symbol) noexcept {
-  return NO;
+  CompilerKit::STLString pkt = Detail::kDebugMagic;
+  pkt += ";SYM=";
+  pkt += symbol;
+  pkt += ";\r";
+
+  if (pkt.size() > kDebugCmdLen) return NO;
+
+  auto ret = ::send(m_socket, pkt.data(), pkt.size(), 0) > 0;
+  return ret;
 }
 
 BOOL NeKernelContract::Break() noexcept {
-  return NO;
+  CompilerKit::STLString pkt = Detail::kDebugMagic;
+  pkt += ";BRK=1;\r";
+
+  auto ret = ::send(m_socket, pkt.data(), pkt.size(), 0) > 0;
+  return ret;
 }
 
 BOOL NeKernelContract::Continue() noexcept {
+  CompilerKit::STLString pkt = Detail::kDebugMagic;
+  pkt += ";CONT=1;\r";
+
+  auto ret = ::send(m_socket, pkt.data(), pkt.size(), 0) > 0;
+  return ret;
   return NO;
 }
 
 BOOL NeKernelContract::Detach() noexcept {
-  return NO;
+  CompilerKit::STLString pkt = Detail::kDebugMagic;
+  pkt += ";DTCH=1;\r";
+
+  auto ret = ::send(m_socket, pkt.data(), pkt.size(), 0) > 0;
+
+  if (ret) ::close(m_socket);
+
+  return ret;
 }
 
 #endif  // DK_NEKERNEL_DEBUGGER

--- a/dev/DebuggerKit/src/NeKernelContractCLI.cc
+++ b/dev/DebuggerKit/src/NeKernelContractCLI.cc
@@ -43,8 +43,7 @@ NECTI_MODULE(DebuggerNeKernel) {
 
     CompilerKit::install_signal(SIGINT, dbgi_ctrlc_handler);
 
-    kKernelDebugger.Attach(kPath, "", kPID);
-    kKernelDebugger.BreakAt("$HANDOVER_START");
+    kKernelDebugger.Attach(kPath, argv[4], kPID);
 
     while (YES) {
       if (kKeepRunning) {


### PR DESCRIPTION
#  v0.0.5 (Arlington)

## Brief

New release of `NeCTI`, this skips to v0.0.5 to be kept in sync with `NeKernel`