### PR TITLE
NeCTI: v0.0.6

### DIFF
--- a/dev/CompilerKit/src/Backend/AssemblerAMD64.cc
+++ b/dev/CompilerKit/src/Backend/AssemblerAMD64.cc
@@ -52,9 +52,8 @@
 
 static char kOutputArch = CompilerKit::kPefArchAMD64;
 
-constexpr auto kIPAlignement = 0x1U;
-
-static std::size_t kCounter = 1UL;
+static constexpr auto kIPAlignement = 0x1U;
+static auto kCounter = 0x1UL;
 
 static std::uintptr_t                                      kOrigin = kPefBaseOrigin;
 static std::vector<std::pair<std::string, std::uintptr_t>> kOriginLabel;


### PR DESCRIPTION
# v0.0.6 (Starship)

## Brief

This release is scheduled to go live once the ext2 is fully implemented. And changes have been fully tested.
<br/>
`necti` is to be bumped alongside `nekernel`

## Notice

This release will be updated in the `superproject` as well.