### PR TITLE
chore: breaking changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ NeCTI is a modern, multi-platform compiler instractucture designed for modularit
 - `src/LibC++` – C++ ABI Library
 - `src/LibStdC++` – Standard C++ Library
 - `src/DebuggerKit` – Debugging Kit written in modern C++
-- `tools/` – C/C++ Frontend Tools
+- `src/Tools/` – C/C++ Frontend Tools
 
 
 ## Requirements:
@@ -32,15 +32,19 @@ NeCTI is a modern, multi-platform compiler instractucture designed for modularit
 
 ## Notice for Contributors:
 
-- Always use `format.sh` before commiting and pushing your code!
+Always use `format.sh` before commiting and pushing your code!
 
 ## Getting Started:
+
+Run the following:
 
 ```sh
 git clone git@github.com:nekernel-org/necti.git
 cd necti
 # Either build the debugger or compiler libraries/tools using nebuild.
 ```
+
+And build the source tree using the NeBuild system.
 
 ## Security
 

--- a/src/CompilerKit/AST.h
+++ b/src/CompilerKit/AST.h
@@ -95,7 +95,7 @@ struct SyntaxLeafList final {
 /// \param needle the string we search for.
 /// \return if we found it or not.
 /// =========================================================== ///
-Bool find_word(STLString haystack, STLString needle) noexcept;
+bool find_word(STLString haystack, STLString needle) noexcept;
 
 /// =========================================================== ///
 /// find a word within strict conditions and returns a range of it.

--- a/src/CompilerKit/Config.h
+++ b/src/CompilerKit/Config.h
@@ -42,8 +42,6 @@
 #define Int32 int
 #define UInt32 unsigned
 
-#define Bool bool
-
 #define Int16 int16_t
 #define UInt16 uint16_t
 
@@ -51,14 +49,13 @@
 #define UInt8 uint8_t
 
 #define Char char
-#define Boolean bool
 
 #include <signal.h>
+#include <stdint.h>
+#include <time.h>
 #include <unistd.h>
 #include <cassert>
-#include <time.h>
 #include <string>
-#include <stdint.h>
 
 #define kDistVersion "v0.0.7-compilerkit"
 #define kDistVersionBCD 0x0002
@@ -78,9 +75,7 @@
 
 #define kDistRelease ToString(kDistReleaseBranch)
 
-#endif // !kDistRelease
-
-#define nullPtr std::nullptr_t
+#endif  // !kDistRelease
 
 #define MUST_PASS(E) assert(E)
 

--- a/src/CompilerKit/ErrorOr.h
+++ b/src/CompilerKit/ErrorOr.h
@@ -30,17 +30,17 @@ class ErrorOr final {
 
  public:
   explicit ErrorOr(ErrorT err) : mId(err) {}
-  explicit ErrorOr(nullPtr null) {}
+  explicit ErrorOr(std::nullptr_t null) {}
   explicit ErrorOr(T klass) : mRef(klass) {}
 
   ErrorOr& operator=(const ErrorOr&) = default;
   ErrorOr(const ErrorOr&)            = default;
 
-  Ref<T> Leak() { return mRef; }
+  Ref<T>& Leak() { return mRef; }
 
   ErrorT Error() { return mId; }
 
-  Bool HasError() { return mId != NECTI_SUCCESS; }
+  bool HasError() { return mId != NECTI_SUCCESS; }
 
   explicit operator bool() { return mRef; }
 

--- a/src/CompilerKit/Ref.h
+++ b/src/CompilerKit/Ref.h
@@ -31,7 +31,7 @@ class Ref final {
   NECTI_COPY_DEFAULT(Ref);
 
  public:
-  explicit Ref(T* cls, const Bool& strong = false) : m_Class(cls), m_Strong(strong) {}
+  explicit Ref(T* cls, const bool& strong = false) : m_Class(cls), m_Strong(strong) {}
 
   Ref& operator=(T ref) {
     *m_Class = ref;
@@ -45,13 +45,13 @@ class Ref final {
 
   T operator*() { return *m_Class; }
 
-  Bool IsStrong() const { return m_Strong; }
+  bool IsStrong() const { return m_Strong; }
 
   explicit operator bool() { return *m_Class; }
 
  private:
   T*   m_Class{nullptr};
-  Bool m_Strong{false};
+  bool m_Strong{false};
 };
 
 // @author Amlal El Mahrouss

--- a/src/CompilerKit/StringKit.h
+++ b/src/CompilerKit/StringKit.h
@@ -84,7 +84,7 @@ struct NEStringBuilder final {
   static NEString FromInt(const char* fmt, int n);
   static NEString FromBool(const char* fmt, bool n);
   static NEString Format(const char* fmt, const char* from);
-  static Bool     Equals(const char* lhs, const char* rhs);
+  static bool     Equals(const char* lhs, const char* rhs);
 };
 
 using NEStringOr  = ErrorOr<NEString>;

--- a/src/CompilerKit/src/AST.cc
+++ b/src/CompilerKit/src/AST.cc
@@ -21,7 +21,7 @@ namespace CompilerKit {
 /// \param haystack base string
 /// \param needle the string we search for.
 /// \return if we found it or not.
-Bool find_word(STLString haystack, STLString needle) noexcept {
+bool find_word(STLString haystack, STLString needle) noexcept {
   auto index = haystack.find(needle);
 
   // check for needle validity.

--- a/src/CompilerKit/src/Backend/AssemblerAMD64.cc
+++ b/src/CompilerKit/src/Backend/AssemblerAMD64.cc
@@ -966,7 +966,7 @@ bool CompilerKit::EncoderAMD64::WriteLine(std::string line, std::string file) {
       {.fName = "si", .fModRM = 0x6}, {.fName = "di", .fModRM = 7},
   };
 
-  Bool foundInstruction = false;
+  bool foundInstruction = false;
 
   for (auto& opcodeAMD64 : kOpcodesAMD64) {
     // strict check here

--- a/src/CompilerKit/src/Backend/AssemblerARM64.cc
+++ b/src/CompilerKit/src/Backend/AssemblerARM64.cc
@@ -21,9 +21,9 @@
 
 #include <CompilerKit/AE.h>
 #include <CompilerKit/AST.h>
+#include <CompilerKit/Config.h>
 #include <CompilerKit/ErrorID.h>
 #include <CompilerKit/PEF.h>
-#include <CompilerKit/Config.h>
 #include <CompilerKit/impl/Aarch64.h>
 #include <CompilerKit/utils/AsmUtils.h>
 #include <algorithm>

--- a/src/CompilerKit/src/Backend/AssemblerPowerPC.cc
+++ b/src/CompilerKit/src/Backend/AssemblerPowerPC.cc
@@ -21,9 +21,9 @@
 
 #include <CompilerKit/AE.h>
 #include <CompilerKit/AST.h>
+#include <CompilerKit/Config.h>
 #include <CompilerKit/ErrorID.h>
 #include <CompilerKit/PEF.h>
-#include <CompilerKit/Config.h>
 #include <CompilerKit/impl/PowerPC.h>
 #include <CompilerKit/utils/AsmUtils.h>
 #include <algorithm>

--- a/src/CompilerKit/src/Frontend/CPlusPlusCompilerAMD64.cc
+++ b/src/CompilerKit/src/Frontend/CPlusPlusCompilerAMD64.cc
@@ -115,10 +115,10 @@ static std::vector<CompilerKit::CompilerKeyword> kKeywords;
 /////////////////////////////////////////
 
 static CompilerKit::AssemblyFactory kAssembler;
-static Boolean                      kInStruct    = false;
-static Boolean                      kOnWhileLoop = false;
-static Boolean                      kOnForLoop   = false;
-static Boolean                      kInBraces    = false;
+static bool                         kInStruct    = false;
+static bool                         kOnWhileLoop = false;
+static bool                         kOnForLoop   = false;
+static bool                         kInBraces    = false;
 static size_t                       kBracesCount = 0UL;
 
 /* @brief C++ compiler backend for the NeKernel C++ driver */
@@ -429,7 +429,7 @@ CompilerKit::SyntaxLeafList::SyntaxLeaf CompilerFrontendCPlusPlusAMD64::Compile(
           varName.erase(varName.find(";"));
         }
 
-        static Boolean typeFound = false;
+        static bool typeFound = false;
 
         for (auto& keyword : kKeywords) {
           if (keyword.keyword_kind == CompilerKit::kKeywordKindType) {
@@ -766,7 +766,7 @@ class AssemblyCPlusPlusInterfaceAMD64 final CK_ASSEMBLY_INTERFACE {
 #define kExtListCxx {".cpp", ".cxx", ".cc", ".c++", ".cp"}
 
 NECTI_MODULE(CompilerCPlusPlusAMD64) {
-  Boolean skip = false;
+  bool skip = false;
 
   kKeywords.emplace_back("if", CompilerKit::kKeywordKindIf);
   kKeywords.emplace_back("else", CompilerKit::kKeywordKindElse);

--- a/src/CompilerKit/src/Linker/DynamicLinker64PEF.cc
+++ b/src/CompilerKit/src/Linker/DynamicLinker64PEF.cc
@@ -19,7 +19,6 @@
 #include <CompilerKit/ErrorID.h>
 #include <CompilerKit/PEF.h>
 #include <CompilerKit/UUID.h>
-#include <CompilerKit/Config.h>
 #include <CompilerKit/utils/CompilerUtils.h>
 #include <filesystem>
 
@@ -54,9 +53,9 @@ static CompilerKit::STLString kOutput           = "a" kPefExt;
 static Int32                  kAbi              = kABITypeNE;
 static Int32                  kSubArch          = kPefNoSubCpu;
 static Int32                  kArch             = CompilerKit::kPefArchInvalid;
-static Bool                   kFatBinaryEnable  = false;
-static Bool                   kStartFound       = false;
-static Bool                   kDuplicateSymbols = false;
+static bool                   kFatBinaryEnable  = false;
+static bool                   kStartFound       = false;
+static bool                   kDuplicateSymbols = false;
 
 /* ld64 is to be found, mld is to be found at runtime. */
 static const Char* kLdDefineSymbol = ":UndefinedSymbol:";

--- a/src/CompilerKit/utils/CompilerUtils.h
+++ b/src/CompilerKit/utils/CompilerUtils.h
@@ -8,8 +8,8 @@
 
 #include <CompilerKit/AST.h>
 #include <CompilerKit/CodeGenerator.h>
-#include <CompilerKit/ErrorID.h>
 #include <CompilerKit/Config.h>
+#include <CompilerKit/ErrorID.h>
 #include <ThirdParty/Dialogs.h>
 #include <iostream>
 

--- a/src/DebuggerKit/Common.inl
+++ b/src/DebuggerKit/Common.inl
@@ -10,12 +10,12 @@
 
 #define kStdOut (std::cout << kRed << "dbg: " << kWhite)
 
-static Bool kKeepRunning = false;
+inline bool kKeepRunning = false;
 
 #ifdef DK_NEKERNEL_DEBUGGER
-static DebuggerKit::NeKernel::NeKernelContract kKernelDebugger;
+inline DebuggerKit::NeKernel::NeKernelContract kKernelDebugger;
 #else
-static DebuggerKit::POSIX::POSIXMachContract kUserDebugger;
+inline DebuggerKit::POSIX::POSIXMachContract kUserDebugger;
 #endif
 
 static DebuggerKit::ProcessID kPID           = 0L;

--- a/src/DebuggerKit/Config.h
+++ b/src/DebuggerKit/Config.h
@@ -41,4 +41,4 @@
 
 #define kDistRelease ToString(kDistReleaseBranch)
 
-#endif // !kDistRelease
+#endif  // !kDistRelease

--- a/src/DebuggerKit/DebuggerContract.h
+++ b/src/DebuggerKit/DebuggerContract.h
@@ -9,10 +9,10 @@
 #include <DebuggerKit/Config.h>
 #include <unordered_map>
 
-#define DK_DEBUGGER_CONTRACT : public ::DebuggerKit::DebuggerContract
+#define DK_DEBUGGER_CONTRACT : public ::DebuggerKit::IDebuggerContract
 
 namespace DebuggerKit {
-class DebuggerContract;
+class IDebuggerContract;
 
 /// =========================================================== ///
 /// \brief Process ID
@@ -28,14 +28,14 @@ typedef char* CAddress;
 /// \brief Debugger contract class in C++, as per the design states.
 /// \author Amlal El Mahrouss
 /// =========================================================== ///
-class DebuggerContract {
+class IDebuggerContract {
  public:
-  explicit DebuggerContract() = default;
-  virtual ~DebuggerContract() = default;
+  explicit IDebuggerContract() = default;
+  virtual ~IDebuggerContract() = default;
 
  public:
-  DebuggerContract& operator=(const DebuggerContract&) = default;
-  DebuggerContract(const DebuggerContract&)            = default;
+  IDebuggerContract& operator=(const IDebuggerContract&) = default;
+  IDebuggerContract(const IDebuggerContract&)            = default;
 
  public:
   virtual bool Attach(std::string path, std::string argv, ProcessID& pid) noexcept = 0;

--- a/src/DebuggerKit/POSIXMachContract.h
+++ b/src/DebuggerKit/POSIXMachContract.h
@@ -45,7 +45,7 @@ class POSIXMachContract final DK_DEBUGGER_CONTRACT {
   POSIXMachContract(const POSIXMachContract&)            = default;
 
  public:
-  Bool Attach(CompilerKit::STLString path, CompilerKit::STLString argv,
+  bool Attach(CompilerKit::STLString path, CompilerKit::STLString argv,
               ProcessID& pid) noexcept override {
     pid = fork();
 
@@ -82,7 +82,7 @@ class POSIXMachContract final DK_DEBUGGER_CONTRACT {
     m_path = path;
   }
 
-  Bool BreakAt(CompilerKit::STLString symbol) noexcept override {
+  bool BreakAt(CompilerKit::STLString symbol) noexcept override {
     if (!m_path.empty() && std::filesystem::exists(m_path) &&
         std::filesystem::is_regular_file(m_path)) {
       auto handle = dlopen(m_path.c_str(), RTLD_LAZY);
@@ -116,7 +116,7 @@ class POSIXMachContract final DK_DEBUGGER_CONTRACT {
   }
 
 #ifdef __APPLE__
-  Bool Break() noexcept override {
+  bool Break() noexcept override {
     task_read_t task;
     task_for_pid(mach_task_self(), m_pid, &task);
 
@@ -125,7 +125,7 @@ class POSIXMachContract final DK_DEBUGGER_CONTRACT {
     return ret == KERN_SUCCESS;
   }
 
-  Bool Continue() noexcept override {
+  bool Continue() noexcept override {
     task_read_t task;
     task_for_pid(mach_task_self(), m_pid, &task);
 
@@ -134,7 +134,7 @@ class POSIXMachContract final DK_DEBUGGER_CONTRACT {
     return ret == KERN_SUCCESS;
   }
 
-  Bool Detach() noexcept override {
+  bool Detach() noexcept override {
     this->Continue();
 
     task_read_t task;

--- a/src/DebuggerKit/src/NeKernelContract.cc
+++ b/src/DebuggerKit/src/NeKernelContract.cc
@@ -21,7 +21,7 @@ NeKernelContract::NeKernelContract() = default;
 
 NeKernelContract::~NeKernelContract() = default;
 
-Bool NeKernelContract::Attach(CompilerKit::STLString path, CompilerKit::STLString argv,
+bool NeKernelContract::Attach(CompilerKit::STLString path, CompilerKit::STLString argv,
                               ProcessID& pid) noexcept {
   if (path.empty() || argv.empty()) return NO;
 
@@ -47,11 +47,11 @@ Bool NeKernelContract::Attach(CompilerKit::STLString path, CompilerKit::STLStrin
   return ret;
 }
 
-Bool NeKernelContract::BreakAt(CompilerKit::STLString symbol) noexcept {
+bool NeKernelContract::BreakAt(CompilerKit::STLString symbol) noexcept {
   CompilerKit::STLString pkt = Detail::kDebugMagic;
-  pkt += ";SYM=";
+  pkt += ";SYM=\"";
   pkt += symbol;
-  pkt += ";\r";
+  pkt += "\";\r";
 
   if (pkt.size() > kDebugCmdLen) return NO;
 
@@ -59,7 +59,7 @@ Bool NeKernelContract::BreakAt(CompilerKit::STLString symbol) noexcept {
   return ret;
 }
 
-Bool NeKernelContract::Break() noexcept {
+bool NeKernelContract::Break() noexcept {
   CompilerKit::STLString pkt = Detail::kDebugMagic;
   pkt += ";BRK=1;\r";
 
@@ -67,7 +67,7 @@ Bool NeKernelContract::Break() noexcept {
   return ret;
 }
 
-Bool NeKernelContract::Continue() noexcept {
+bool NeKernelContract::Continue() noexcept {
   CompilerKit::STLString pkt = Detail::kDebugMagic;
   pkt += ";CONT=1;\r";
 
@@ -76,7 +76,7 @@ Bool NeKernelContract::Continue() noexcept {
   return NO;
 }
 
-Bool NeKernelContract::Detach() noexcept {
+bool NeKernelContract::Detach() noexcept {
   CompilerKit::STLString pkt = Detail::kDebugMagic;
   pkt += ";DTCH=1;\r";
 

--- a/src/DebuggerKit/src/NeKernelContractCLI.cc
+++ b/src/DebuggerKit/src/NeKernelContractCLI.cc
@@ -11,7 +11,7 @@
 #include <ThirdParty/Dialogs.h>
 #include <string>
 
-#include <DebuggerKit/CommonCLI.inl>
+#include <DebuggerKit/Common.inl>
 
 using namespace DebuggerKit::NeKernel;
 

--- a/src/DebuggerKit/src/POSIXMachContractCLI.cc
+++ b/src/DebuggerKit/src/POSIXMachContractCLI.cc
@@ -9,9 +9,10 @@
 #include <CompilerKit/Config.h>
 #include <DebuggerKit/POSIXMachContract.h>
 #include <ThirdParty/Dialogs.h>
-#include <DebuggerKit/CommonCLI.inl>
 
 #ifdef __APPLE__
+#include <DebuggerKit/Common.inl>
+
 /// @internal
 /// @brief Handles CTRL-C signal on debugger.
 static void dbgi_ctrlc_handler(std::int32_t _) {

--- a/src/LibC++/new.h
+++ b/src/LibC++/new.h
@@ -11,12 +11,12 @@
 namespace std {
 struct nothrow_t final {
   explicit nothrow_t() = default;
-  ~nothrow_t() = default;
+  ~nothrow_t()         = default;
 };
 
 struct placement_t final {
   explicit placement_t() = default;
-  ~placement_t() = default;
+  ~placement_t()         = default;
 
   void*   __base{};
   int32_t __align{};

--- a/src/Tools/asm.cc
+++ b/src/Tools/asm.cc
@@ -8,7 +8,6 @@
 /// @brief Assembler frontend.
 
 #include <CompilerKit/Config.h>
-#include <CompilerKit/Config.h>
 #include <cstring>
 #include <vector>
 

--- a/src/Tools/cppdrv.cc
+++ b/src/Tools/cppdrv.cc
@@ -9,7 +9,6 @@
 
 #include <CompilerKit/Config.h>
 #include <CompilerKit/ErrorID.h>
-#include <CompilerKit/Config.h>
 #include <cstring>
 #include <iostream>
 #include <vector>

--- a/src/Tools/pef-amd64-cxxdrv.cc
+++ b/src/Tools/pef-amd64-cxxdrv.cc
@@ -9,7 +9,6 @@
 
 #include <CompilerKit/Config.h>
 #include <CompilerKit/ErrorID.h>
-#include <CompilerKit/Config.h>
 #include <CompilerKit/utils/CompilerUtils.h>
 #include <CompilerKit/utils/DylibHelpers.h>
 

--- a/src/Tools/pef-arm64-cdrv.cc
+++ b/src/Tools/pef-arm64-cdrv.cc
@@ -9,7 +9,6 @@
 
 #include <CompilerKit/Config.h>
 #include <CompilerKit/ErrorID.h>
-#include <CompilerKit/Config.h>
 #include <CompilerKit/utils/CompilerUtils.h>
 #include <CompilerKit/utils/DylibHelpers.h>
 


### PR DESCRIPTION
chore! reworked source code to exclude `Bool`, `Boolean`, and `nullPtr` macros.
fix: ErrorOr: Return `Ref<T>&` when using Leak.